### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/Publish Docker.yml
+++ b/.github/workflows/Publish Docker.yml
@@ -45,7 +45,7 @@ jobs:
         npm install
         npm run build
     - name: Publish Docker
-      uses: elgohr/Publish-Docker-Github-Action@2.11
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         # The name of the image you would like to push
         # name: ${{secrets.DOCKER_PROGRAM}}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore